### PR TITLE
sign all files (tags, logs etc)

### DIFF
--- a/make-apt.sh
+++ b/make-apt.sh
@@ -57,3 +57,10 @@ cp -r $MXEDIR/log repos/
 for d in list deb-control log; do
     tar -C repos -cJf repos/$d.tar.xz $d
 done
+
+find repos/{deb-control*,list*,tar,build-pkg.log,jessie,wheezy,log*} \
+    -type f -print0 \
+| xargs -0 --max-args 1000 -I % sha256sum % \
+| sed 's@  repos/@  @' \
+| gpg --clearsign \
+> repos/files.sha256sum.asc


### PR DESCRIPTION
Fix https://github.com/mxe/mxe-apt/issues/5
See [the output](https://gist.githubusercontent.com/starius/f609e954f9591727b36b5e68f2b9aca7/raw/5155c4bc04b8486ef75b37c88ca0a827852c454c/files.sha256sum.asc) for [the recent release](http://pkg.mxe.cc/releases/2017-02-11/).